### PR TITLE
Refatorando sripts de testes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ API REST criada para estudos de testes de software com autenticação via JWT.
 
 1. Clone o projeto:
    ```bash
-   git clone <URL_DO_REPOSITORIO>
-   cd <nome-da-pasta>
+   git clone https://github.com/Ali-Maia/login-api.git
+   cd login-api
    ```
 
 2. Instale as dependências:

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "dev": "nodemon src/server.js",
     "test": "mocha ./src/tests/**/*.test.js --reporter mochawesome --timeout 2000",
     "test:auth": "mocha ./src/tests/auth/**/*.test.js --reporter mochawesome --timeout 2000",
-    "test:users": "mocha ./src/tests/users/**/*.test.js --reporter mochawesome --timeout 2000",
     "test:auth:login": "mocha ./src/tests/auth/login.test.js --reporter mochawesome --timeout 2000",
     "test:auth:register": "mocha ./src/tests/auth/register.test.js --reporter mochawesome --timeout 2000",
-    "test:auth:reset": "mocha ./src/tests/auth/reset-password.test.js --reporter mochawesome --timeout 2000"
+    "test:auth:reset": "mocha ./src/tests/auth/reset-password.test.js --reporter mochawesome --timeout 2000",
+    "test:users": "mocha ./src/tests/users/**/*.test.js --reporter mochawesome --timeout 2000",
+    "test:users:profile": "mocha ./src/tests/users/profile.test.js --reporter mochawesome --timeout 2000"
   },
   "keywords": [
     "api",

--- a/src/helpers/common.js
+++ b/src/helpers/common.js
@@ -1,0 +1,59 @@
+const request = require('supertest')
+
+require('dotenv').config()
+const baseUrl = process.env.BASE_URL
+
+
+const apiAuthLogin = async (email, senha, rememberMe) => {
+  const resposta = await request(baseUrl)
+  .post('/api/auth/login')
+  .set('Content-Type', 'application/json')
+  .send({ "email": email, "password": senha, "rememberMe": rememberMe })
+
+  return resposta
+}
+
+const apiAuthResetPassword = async (email) => {
+  const resposta = await request(baseUrl)
+  .post('/api/auth/reset-password')
+  .set('Content-Type', 'application/json')
+  .send({ email: email })
+
+  return resposta
+}
+
+const apiUsersProfileAuthenticated = async (token) => {
+  const resposta = await request(baseUrl)
+    .get('/api/users/profile')
+    .set('Content-Type', 'application/json')
+    .set('Authorization', `Bearer ${token}`)
+
+  return resposta
+}
+
+const apiUsersProfileUpdate = async (name, token) => {
+  const resposta = await request(baseUrl)
+  .put('/api/users/profile')
+  .set('Content-Type', 'application/json')
+  .set('Authorization', `Bearer ${token}`)
+  .send({name : name})
+
+  return resposta
+}
+
+const apiUsersProfileDelete = async (token) => {
+  const resposta = await request(baseUrl)
+  .delete('/api/users/delete')
+  .set('Content-Type', 'application/json')
+  .set('Authorization', `Bearer ${token}`)
+
+  return resposta
+}
+
+module.exports = { 
+  apiAuthLogin, 
+  apiAuthResetPassword, 
+  apiUsersProfileAuthenticated, 
+  apiUsersProfileUpdate, 
+  apiUsersProfileDelete 
+}

--- a/src/tests/auth/reset-password.test.js
+++ b/src/tests/auth/reset-password.test.js
@@ -1,13 +1,11 @@
-const request = require('supertest')
 const { expect } = require('chai')
 
-const { baseUrl } = require('../../config/environment')
 const { cadastrarUsuario } = require('../../helpers/auth')
 const gerarUsuario = require('../../helpers/gerarUsuario')
+const { apiAuthResetPassword } = require('../../helpers/common')
 
 const usuario = gerarUsuario()
 const login = { ...usuario }
-
 
 
 describe('Reset de Senha - POST /api/auth/reset-password', () => {
@@ -18,20 +16,14 @@ describe('Reset de Senha - POST /api/auth/reset-password', () => {
   })
 
   it('StatusCode 200 - Deve enviar e-mail de redefinição de senha com sucesso, quando e-mail for válido', async () => {
-    const resposta = await request(baseUrl)
-      .post('/api/auth/reset-password')
-      .set('Content-Type', 'application/json')
-      .send({ email: login.email })
+    const resposta = await apiAuthResetPassword(login.email)
 
     expect(resposta.status).to.equal(200)
     expect(resposta.body.message).to.equal('Email de redefinição enviado com sucesso')
   })
 
   it('StatusCode 404 - Não deve permitir redefinição de senha para e-mail inexistente', async () => {
-    const resposta = await request(baseUrl)
-      .post('/api/auth/reset-password')
-      .set('Content-Type', 'application/json')
-      .send({ email: "rafael@email.com" })
+    const resposta = await apiAuthResetPassword("rafael@email.com")
 
     expect(resposta.status).to.equal(404)
     expect(resposta.body).to.have.property('error')

--- a/src/tests/users/profile.test.js
+++ b/src/tests/users/profile.test.js
@@ -4,10 +4,10 @@ const { expect } = require('chai')
 const { baseUrl } = require('../../config/environment')
 const { cadastrarUsuario } = require('../../helpers/auth')
 const gerarUsuario = require('../../helpers/gerarUsuario')
+const { apiUsersProfileAuthenticated, apiUsersProfileUpdate, apiUsersProfileDelete } = require('../../helpers/common')
 
 const usuario = gerarUsuario()
 const login = { ...usuario }
-
 
 
 describe('Usuários', () => {
@@ -19,10 +19,7 @@ describe('Usuários', () => {
 
   describe('GET /api/users/profile', () => {
     it('StatusCode 200 - Deve retornar o perfil do usuário autenticado', async () => {
-      const resposta = await request(baseUrl)
-        .get('/api/users/profile')
-        .set('Content-Type', 'application/json')
-        .set('Authorization', `Bearer ${token}`)
+      const resposta = await apiUsersProfileAuthenticated(token)
 
       expect(resposta.status).to.equal(200)
       expect(resposta.body.user).to.have.property('name')
@@ -40,55 +37,42 @@ describe('Usuários', () => {
     })
 
     it('StatusCode 401 - Deve retornar um erro quando o token for inválido', async () => {
-      const resposta = await request(baseUrl)
-        .get('/api/users/profile')
-        .set('Content-Type', 'application/json')
-        .set('Authorization', `Bearer ${token}123`)
+      const resposta = await apiUsersProfileAuthenticated(`${token}123`)
 
       expect(resposta.status).to.equal(401)
     })
+  })
+
+  describe('PUT /api/users/profile', () => {
+    it('StatusCode 200 - Deve atualizar o perfil do usuário se tiver token válido', async () => {
+      const resposta = await apiUsersProfileUpdate('Clebinho Junior', token)
+
+      expect(resposta.status).to.equal(200)
     })
 
-    describe('PUT /api/users/profile', () => {
-      it('StatusCode 200 - Deve atualizar o perfil do usuário se tiver token válido', async () => {
-        const resposta = await request(baseUrl)
-        .put('/api/users/profile')
-        .set('Content-Type', 'application/json')
-        .set('Authorization', `Bearer ${token}`)
-        .send({name : 'Clebinho Junior'})
-  
-        expect(resposta.status).to.equal(200)
-      })
+    it('StatusCode 401 - Deve retornar erro quando usuário não estiver autenticado', async () => {
+      const resposta = await request(baseUrl)
+      .put('/api/users/profile')
+      .set('Content-Type', 'application/json')
+      .send({name : 'Clebinho Junior'})
 
-      it('StatusCode 401 - Deve retornar erro quando usuário não estiver autenticado', async () => {
-        const resposta = await request(baseUrl)
-        .put('/api/users/profile')
-        .set('Content-Type', 'application/json')
-        .send({name : 'Clebinho Junior'})
-
-        expect(resposta.status).to.equal(401)
-      })
-    })
-
-    describe('DELETE /api/users/delete', () => {
-      it('StatusCode 200 - Deve deletar o usuário quando estiver autenticado', async () => {
-        const resposta = await request(baseUrl)
-        .delete('/api/users/delete')
-        .set('Content-Type', 'application/json')
-        .set('Authorization', `Bearer ${token}`)
-
-        expect(resposta.status).to.equal(200)
-        expect(resposta.body).to.have.property('message')
-      })
-
-      it('StatusCode 401 - Deve retornar um erro quando o usuário não estiver autenticado', async () => {
-        const resposta = await request(baseUrl)
-        .delete('/api/users/delete')
-        .set('Content-Type', 'application/json')
-        .set('Authorization', `Bearer ${token}123`)
-
-        expect(resposta.status).to.equal(401)
-        expect(resposta.body).to.have.property('message')
-      })
+      expect(resposta.status).to.equal(401)
     })
   })
+
+  describe('DELETE /api/users/delete', () => {
+    it('StatusCode 200 - Deve deletar o usuário quando estiver autenticado', async () => {
+      const resposta = await apiUsersProfileDelete(token)
+
+      expect(resposta.status).to.equal(200)
+      expect(resposta.body).to.have.property('message')
+    })
+
+    it('StatusCode 401 - Deve retornar um erro quando o usuário não estiver autenticado', async () => {
+      const resposta = await apiUsersProfileDelete(`${token}123`)
+
+      expect(resposta.status).to.equal(401)
+      expect(resposta.body).to.have.property('message')
+    })
+  })
+})


### PR DESCRIPTION
Título
Refatoração dos testes e criação de funções reutilizáveis

Descrição:
Adicionada nova entrada no package.json para executar testes isolados.
"test:users:profile": "mocha ./src/tests/users/profile.test.js --reporter mochawesome --timeout 2000"

Refatorados os testes que utilizavam chamadas repetitivas da API, centralizando a lógica no common.js
Criado o arquivo common.js na pasta helpers com as seguintes funções reutilizáveis.
apiAuthLogin()
apiAuthResetPassword()
apiUsersProfileAuthenticated()
apiUsersProfileUpdate()
apiUsersProfileDelete()

README.md atualizado com as novas mudanças

Agora os testes apenas importam as funções e realizam as chamadas de forma mais limpa e padronizada.
Essa mudança melhora a legibilidade do código, facilita a manutenção e evita duplicação.